### PR TITLE
Fix Infinity in pyt() + use Math.hypot when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,4 +161,5 @@ These are not evaluated by simplify.
 	max(a,b,…) 	Get the largest (“maximum”) number in the list
 	pyt(a, b) 	Pythagorean function, i.e. the c in “c2 = a2 + b2“
 	pow(x, y) 	xy. This is exactly the same as “x^y”. It’s just provided since it’s in the Math object from JavaScript
-	atan2(y, x) 	arc tangent of x/y. i.e. the angle between (0, 0) and (x, y) in radians.
+	atan2(y, x) Arc tangent of x/y. i.e. the angle between (0, 0) and (x, y) in radians.
+	hypot(a,b)  The square root of the sum of squares of its arguments.

--- a/parser.js
+++ b/parser.js
@@ -340,8 +340,17 @@ var Parser = (function (scope) {
 	}
 
 	// TODO: use hypot that doesn't overflow
-	function pyt(a, b) {
-		return Math.sqrt(a * a + b * b);
+	function hypot() {
+		if(Math.hypot) return Math.hypot.apply(this, arguments);
+		var y = 0;
+		var length = arguments.length;
+		for (var i = 0; i < length; i++) {
+			if (arguments[i] === Infinity || arguments[i] === -Infinity) {
+				return Infinity;
+			}
+			y += arguments[i] * arguments[i];
+		}
+		return Math.sqrt(y);
 	}
 
 	function append(a, b) {
@@ -400,7 +409,8 @@ var Parser = (function (scope) {
 			"fac": fac,
 			"min": Math.min,
 			"max": Math.max,
-			"pyt": pyt,
+			"hypot": hypot,
+			"pyt": hypot, // backward compat
 			"pow": Math.pow,
 			"atan2": Math.atan2
 		};
@@ -441,7 +451,8 @@ var Parser = (function (scope) {
 		exp: Math.exp,
 		min: Math.min,
 		max: Math.max,
-		pyt: pyt,
+		hypot: hypot,
+		pyt: hypot, // backward compat
 		pow: Math.pow,
 		atan2: Math.atan2,
 		E: Math.E,


### PR DESCRIPTION
Make pyt support more than 2 arguments just like Math.hypot
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot