### PR TITLE
len function added, round has second parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ These are not evaluated by simplify.
 	atan2(y, x) Arc tangent of x/y. i.e. the angle between (0, 0) and (x, y) in radians.
 	hypot(a,b)  The square root of the sum of squares of its arguments.
 	if(c, a, b) The condition function where c is condition, a is result if c is true, b is result if c is false
+    len(n)      The character length of n. i.e. len(123) = 3
 
 ### Tests ###
 

--- a/README.md
+++ b/README.md
@@ -148,27 +148,27 @@ only difference from an outside point of view, is that they cannot be called
 with multiple arguments and they are evaluated by the simplify method if their
 arguments are constant.
 
-	Function  Description
-	sin(x)    Sine of x (x is in radians)
-	cos(x)    Cosine of x (x is in radians)
-	tan(x)    Tangent of x (x is… well, you know)
-	asin(x)   Arc sine of x (in radians)
-	acos(x)   Arc cosine of x (in radians)
-	atan(x)   Arc tangent of x (in radians)
-	sinh(x)   Hyperbolic sine of x (x is in radians)
-	cosh(x)   Hyperbolic cosine of x (x is in radians)
-	tanh(x)   Hyperbolic tangent of x (x is… well, you know)
-	asinh(x)  Hyperbolic arc sine of x (in radians)
-	acosh(x)  Hyperbolic arc cosine of x (in radians)
-	atanh(x)  Hyperbolic arc tangent of x (in radians)
-	sqrt(x)   Square root of x. Result is NaN (Not a Number) if x is negative.
-	log(x)    Natural logarithm of x (not base-10). It’s log instead of ln because that’s what JavaScript calls it.
-	abs(x)    Absolute value (magnatude) of x
-	ceil(x)   Ceiling of x — the smallest integer that’s >= x.
-	floor(x)  Floor of x — the largest integer that’s <= x.
-	round(x)  X, rounded to the nearest integer, using “gradeschool rounding”.
-	trunc(x)  Integral part of a X, looks like floor(x) unless for negative number.
-	exp(x)    ex (exponential/antilogarithm function with base e) Pre-defined functions
+	Function       Description
+	sin(x)         Sine of x (x is in radians)
+	cos(x)         Cosine of x (x is in radians)
+	tan(x)         Tangent of x (x is… well, you know)
+	asin(x)        Arc sine of x (in radians)
+	acos(x)        Arc cosine of x (in radians)
+	atan(x)        Arc tangent of x (in radians)
+	sinh(x)        Hyperbolic sine of x (x is in radians)
+	cosh(x)        Hyperbolic cosine of x (x is in radians)
+	tanh(x)        Hyperbolic tangent of x (x is… well, you know)
+	asinh(x)       Hyperbolic arc sine of x (in radians)
+	acosh(x)       Hyperbolic arc cosine of x (in radians)
+	atanh(x)       Hyperbolic arc tangent of x (in radians)
+	sqrt(x)        Square root of x. Result is NaN (Not a Number) if x is negative.
+	log(x)         Natural logarithm of x (not base-10). It’s log instead of ln because that’s what JavaScript calls it.
+	abs(x)         Absolute value (magnatude) of x
+	ceil(x)        Ceiling of x — the smallest integer that’s >= x.
+	floor(x)       Floor of x — the largest integer that’s <= x.
+	round(x, n)    X, rounded to the nearest integer or to n decimal places, using “gradeschool rounding”.
+	trunc(x)       Integral part of a X, looks like floor(x) unless for negative number.
+	exp(x)         ex (exponential/antilogarithm function with base e) Pre-defined functions
 
 Besides the “operator” functions, there are several pre-defined functions. You
 can provide your own, by binding variables to normal JavaScript functions.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ string concatenation) — and bind from left to right (yes, even exponentiation�
 it’s simpler that way).
 
 Inside the first argument of the if function can be used these operators to compare expressions:
+
 	==		Equal
 	!=		Not equal
 	>		Greater than

--- a/parser.js
+++ b/parser.js
@@ -406,6 +406,11 @@ var Parser = (function (scope) {
 		return cond ? yep : nope;
 	}
 
+	function len(val) {
+		if (typeof val === 'undefined') val = '';
+		return val.toString().length;
+	}
+
 	function append(a, b) {
 		if (Object.prototype.toString.call(a) != "[object Array]") {
 			return [a, b];
@@ -481,7 +486,8 @@ var Parser = (function (scope) {
 			"pyt": hypot, // backward compat
 			"pow": Math.pow,
 			"atan2": Math.atan2,
-			"if": condition
+			"if": condition,
+			"len": len
 		};
 
 		this.consts = {
@@ -532,6 +538,7 @@ var Parser = (function (scope) {
 		pow: Math.pow,
 		atan2: Math.atan2,
 		if: condition,
+		len: len,
 		E: Math.E,
 		PI: Math.PI
 	};

--- a/parser.js
+++ b/parser.js
@@ -411,6 +411,42 @@ var Parser = (function (scope) {
 		return val.toString().length;
 	}
 
+	/**
+	* Decimal adjustment of a number.
+	*
+	* @param {String}  type  The type of adjustment.
+	* @param {Number}  value The number.
+	* @param {Integer} exp   The exponent (the 10 logarithm of the adjustment base).
+	* @return {Number} The adjusted value.
+	*/
+	function decimalAdjust(type, value, exp) {
+		// If the exp is undefined or zero...
+		if (typeof exp === 'undefined' || +exp === 0) {
+			return Math[type](value);
+		}
+		value = +value;
+		exp = -(+exp);
+		// If the value is not a number or the exp is not an integer...
+		if (isNaN(value) || !(typeof exp === 'number' && exp % 1 === 0)) {
+			return NaN;
+		}
+		// Shift
+		value = value.toString().split('e');
+		value = Math[type](+(value[0] + 'e' + (value[1] ? (+value[1] - exp) : -exp)));
+		// Shift back
+		value = value.toString().split('e');
+		return +(value[0] + 'e' + (value[1] ? (+value[1] + exp) : exp));
+	}
+
+	function round(value, exp) {
+		// it comes as an array for some reason
+		if (value instanceof Array) {
+			exp = value[1]
+			value = value[0];
+		}
+		return decimalAdjust('round', value, exp);
+	}
+
 	function append(a, b) {
 		if (Object.prototype.toString.call(a) != "[object Array]") {
 			return [a, b];
@@ -452,7 +488,7 @@ var Parser = (function (scope) {
 			"abs": Math.abs,
 			"ceil": Math.ceil,
 			"floor": Math.floor,
-			"round": Math.round,
+			"round": round,
 			"trunc": trunc,
 			"-": neg,
 			"exp": Math.exp
@@ -526,7 +562,7 @@ var Parser = (function (scope) {
 		abs: Math.abs,
 		ceil: Math.ceil,
 		floor: Math.floor,
-		round: Math.round,
+		round: round,
 		trunc: trunc,
 		random: random,
 		fac: fac,

--- a/test/parserSpec.js
+++ b/test/parserSpec.js
@@ -177,6 +177,24 @@ describe("Parser", function() {
             expect(Parser.evaluate("if(3 and 6, if(45 > 5 * 11, 3 * 3, 2.4), 0)")).to.equal(2.4);
         });
     });
+
+    describe("#len()", function() {
+        it("len(1)", function() {
+            expect(Parser.evaluate("len(1)")).to.equal(1);
+        });
+        it("len(0)", function() {
+            expect(Parser.evaluate("len(0)")).to.equal(1);
+        });
+        it("len()", function() {
+            expect(Parser.evaluate("len()")).to.equal(0);
+        });
+        it("len(12345)", function() {
+            expect(Parser.evaluate("len(12345)")).to.equal(5);
+        });
+        it("len('string')", function() {
+            expect(Parser.evaluate("len('string')")).to.equal(6);
+        });
+    });
 });
 
 /* @todo

--- a/test/parserSpec.js
+++ b/test/parserSpec.js
@@ -195,6 +195,27 @@ describe("Parser", function() {
             expect(Parser.evaluate("len('string')")).to.equal(6);
         });
     });
+
+    describe("#round()", function() {
+        it("round(663)", function() {
+            expect(Parser.evaluate("round(663)")).to.equal(663);
+        });
+        it("round(663, 0)", function() {
+            expect(Parser.evaluate("round(663, 0)")).to.equal(663);
+        });
+        it("round(662.79)", function() {
+            expect(Parser.evaluate("round(662.79)")).to.equal(663);
+        });
+        it("round(662.79, 1)", function() {
+            expect(Parser.evaluate("round(662.79, 1)")).to.equal(662.8);
+        });
+        it("round(54.1, -1)", function() {
+            expect(Parser.evaluate("round(54.1, -1)")).to.equal(50);
+        });
+        it("round(-23.67, 1)", function() {
+            expect(Parser.evaluate("round(-23.67, 1)")).to.equal(-23.7);
+        });
+    });
 });
 
 /* @todo


### PR DESCRIPTION
1) len function added. Inspiration is from MS Excel [LEN function](https://support.office.com/en-us/article/LEN-LENB-functions-29236f94-cedc-429d-affd-b5e33d2c67cb).
2) round takes a second parameter the same as MS Excel's [ROUND](https://support.office.com/en-us/article/ROUND-function-c018c5d8-40fb-4053-90b1-b3e7f61a213c) function does. Implementation was inspired by [Decimal Rounding](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Math/round#Decimal_rounding) function by Mozilla with one exception. The exp is `-1 * exp` because it behaved the opposite than the MS round function and TBH it wasn't logical.

I had fun time with `function round(value, exp) {}`. When I call it as `round(1, 1)`, `value = [1, 1]` and `exp = 'undefined`. Couldn't found out why so I just played with it.

It will be easy to add `floor(X, n)` and `ceil(X, n)` as well (described in the Decimal Rounding link), but I'm in a hurry.

Tests are part of this PR, documentation updated.