### PR TITLE
Quote "if" for Parser.values

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -531,7 +531,7 @@ var Parser = (function (scope) {
 		pyt: hypot, // backward compat
 		pow: Math.pow,
 		atan2: Math.atan2,
-		if: condition,
+		"if": condition,
 		E: Math.E,
 		PI: Math.PI
 	};


### PR DESCRIPTION
For IE8 and below reserved keywords should be quoted, otherwise, an error occurs "Expected identifier, string or number".