### PR TITLE
Fix 10/-1 parity error and add tests

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -702,6 +702,7 @@ var Parser = (function (scope) {
 			if (this.tmpprio < 0 || this.tmpprio >= 10) {
 				this.error_parsing(this.pos, "unmatched \"()\"");
 			}
+
 			while (operstack.length > 0) {
 				var tmp = operstack.pop();
 				tokenstack.push(tmp);
@@ -948,7 +949,7 @@ var Parser = (function (scope) {
 				this.tokenindex = "%";
 			}
 			else if (code === 94) { // ^
-				this.tokenprio = 5;
+				this.tokenprio = 6;
 				this.tokenindex = "^";
 			}
 			else {
@@ -1035,7 +1036,7 @@ var Parser = (function (scope) {
 			}
 			if (str.length > 0 && (str in this.ops1)) {
 				this.tokenindex = str;
-				this.tokenprio = 5;
+				this.tokenprio = 7;
 				this.pos += str.length;
 				return true;
 			}
@@ -1055,7 +1056,7 @@ var Parser = (function (scope) {
 			}
 			if (str.length > 0 && (str in this.ops2)) {
 				this.tokenindex = str;
-				this.tokenprio = 5;
+				this.tokenprio = 7;
 				this.pos += str.length;
 				return true;
 			}

--- a/parser.js
+++ b/parser.js
@@ -585,7 +585,7 @@ var Parser = (function (scope) {
 				if (this.isOperator()) {
 					if (this.isSign() && (expected & SIGN)) {
 						if (this.isNegativeSign()) {
-							this.tokenprio = 2;
+							this.tokenprio = 5;
 							this.tokenindex = "-";
 							noperators++;
 							this.addfunc(tokenstack, operstack, TOP1);

--- a/test/parserSpec.js
+++ b/test/parserSpec.js
@@ -7,30 +7,39 @@ describe("Parser", function() {
         it("2 ^ x", function() {
             expect(Parser.evaluate("2 ^ x", {x: 3})).to.equal(8);
         });
+
         it("2 * x + 1", function() {
             expect(Parser.evaluate("2 * x + 1", {x: 3})).to.equal(7);
         });
+
         it("2 + 3 * x", function() {
             expect(Parser.evaluate("2 + 3 * x", {x: 4})).to.equal(14);
         });
+
         it("(2 + 3) * x", function() {
             expect(Parser.evaluate("(2 + 3) * x", {x: 4})).to.equal(20);
         });
+
         it("2-3^x", function() {
             expect(Parser.evaluate("2-3^x", {x: 4})).to.equal(-79);
         });
+
         it("-2-3^x", function() {
             expect(Parser.evaluate("-2-3^x", {x: 4})).to.equal(-83);
         });
+
         it("-3^x", function() {
             expect(Parser.evaluate("-3^x", {x: 4})).to.equal(-81);
         });
+
         it("(-3)^x", function() {
             expect(Parser.evaluate("(-3)^x", {x: 4})).to.equal(81);
         });
+
         it("2 ^ x.y", function() {
             expect(Parser.evaluate("2^x.y", {x: { y: 3} })).to.equal(8);
         });
+
         it("2 + 3 * foo.bar.baz", function() {
             expect(Parser.evaluate("2 + 3 * foo.bar.baz", {foo: {bar: {baz: 4}}})).to.equal(14);
         });

--- a/test/parserSpec.js
+++ b/test/parserSpec.js
@@ -34,6 +34,38 @@ describe("Parser", function() {
         it("2 + 3 * foo.bar.baz", function() {
             expect(Parser.evaluate("2 + 3 * foo.bar.baz", {foo: {bar: {baz: 4}}})).to.equal(14);
         });
+
+        it('10/-1', function () {
+          expect(Parser.evaluate('10/-1')).to.equal(-10);
+        });
+
+        it('10*-1', function () {
+          expect(Parser.evaluate('10*-1')).to.equal(-10);
+        });
+
+        it('10*-x', function () {
+          expect(Parser.evaluate('10*-x', {x: 1})).to.equal(-10);
+        });
+
+        it('10+-1', function () {
+          expect(Parser.evaluate('10+-1')).to.equal(9);
+        });
+
+        it('10/+1', function () {
+          expect(Parser.evaluate('10/+1')).to.equal(10);
+        });
+
+        it('10*+1', function () {
+          expect(Parser.evaluate('10*+1')).to.equal(10);
+        });
+
+        it('10*+x', function () {
+          expect(Parser.evaluate('10*+x', {x: 1})).to.equal(10);
+        });
+
+        it('10+ +1', function () {
+          expect(Parser.evaluate('10+ +1')).to.equal(11);
+        });
     });
     describe("#substitute()", function() {
         var expr = Parser.parse("2 * x + 1");


### PR DESCRIPTION
Fixes #40. Ping @silentmatt @cashbit. Thought this would be very complicated, but your advice was spot on! Can't guarantee 100% **everything** is correct now, but this adds previously-failing tests and tweaks `tokenprio` to get them to pass.

Thanks for the help!